### PR TITLE
remove --disable-shared from configure

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -16,4 +16,9 @@ share {
   plugin Extract => 'tar.gz';
   plugin 'Build::Autoconf' => ();
 
+  build [
+    '%{configure}',
+    '%{make}',
+    '%{make} install',
+  ];
 };


### PR DESCRIPTION
`Alien::Build::Plugin::Build::Autoconf` disables shared library builds by default. Not sure if this is the best way to manage this. Is there a use case for static only?