### PR TITLE
ffi builds: Install curl-config and curl.exe to /dynamic

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -102,9 +102,10 @@ share {
 
   requires 'Path::Tiny';
 
+  my $ffi_target = '%{.install.autoconf_prefix}/dynamic';
   ffi {
     build [
-      "%{configure} --enable-shared --disable-static --libdir=%{.install.autoconf_prefix}/dynamic @acflags",
+      "%{configure} --enable-shared --disable-static --bindir=$ffi_target --libdir=$ffi_target @acflags",
       '%{make}',
       '%{make} install',
       sub {


### PR DESCRIPTION
This also gets the pkgconfig file, .dll.a and .la files.
The former is useful, the other two should (hopefully)
have no real effect.

updates issue #10

(This is a resubmission of PR #11 following the repo move).